### PR TITLE
Replace Willow w/ swift-log, Bitrise w/ GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_11.4.1.app
       - name: Test in Debug
         run: swift test -c debug
-      - name: Test in Release
-        run: swift test -c release
 
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      # Checks-out the repo. More at: https://github.com/actions/checkout
+      - uses: actions/checkout@v2
+      - name: Select Xcode version
+        run: sudo xcode-select -switch /Applications/Xcode_11.4.1.app
+      - name: Test in Debug
+        run: swift test -c debug
+      - name: Test in Release
+        run: swift test -c release
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Didstopia/SwiftAction@v1.0.2
+        with:
+          swift-action: test --enable-test-discovery

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Build and test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build-macos:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Tests/WAKitTests/XCTestManifests.swift
 
 /spectest
+.vscode

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "SwiftCLI",
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
@@ -26,15 +35,6 @@
           "branch": null,
           "revision": "200c21588c0126c2d4cab89f2776ee5296a3b90a",
           "version": "0.1.1"
-        }
-      },
-      {
-        "package": "Willow",
-        "repositoryURL": "https://github.com/Nike-Inc/Willow",
-        "state": {
-          "branch": null,
-          "revision": "d1304b6374cace1e4008b5f5faec7ce973f54ede",
-          "version": "5.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/akkyie/SwiftLEB", from: "0.1.0"),
         .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.0.0"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "3.1.4"),
-        .package(url: "https://github.com/Nike-Inc/Willow", from: "5.1.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -33,7 +33,7 @@ let package = Package(
         ),
         .target(
             name: "CLI",
-            dependencies: ["WAKit", "SwiftCLI", "Rainbow", "Willow"],
+            dependencies: ["WAKit", "SwiftCLI", "Rainbow", "Logging"],
             path: "./Sources/CLI"
         ),
     ],


### PR DESCRIPTION
Willow (even its latest version) currently breaks the build with this error:

```
error: target at 'WAKit/.build/checkouts/Willow' contains mixed language source files; 
feature not supported
```

Apple's [`swift-log`](https://github.com/apple/swift-log.git) seems to be a well-supported alternative, it was quite easy to replace Willow with it.

GitHub Actions now test on both macOS and Linux.